### PR TITLE
added (american-spelled) foaf_organiZations

### DIFF
--- a/corelib-definitions/src/main/java/eu/europeana/corelib/definitions/edm/beans/BriefBean.java
+++ b/corelib-definitions/src/main/java/eu/europeana/corelib/definitions/edm/beans/BriefBean.java
@@ -20,6 +20,12 @@ public interface BriefBean extends IdBean {
 
     /**
      *
+     * @return foaf_organization (organizations)
+     */
+    String[] getOrganizations();
+
+    /**
+     *
      * @return edm:object
      */
     String[] getEdmObject();

--- a/corelib-storage/src/main/java/eu/europeana/corelib/solr/bean/impl/BriefBeanImpl.java
+++ b/corelib-storage/src/main/java/eu/europeana/corelib/solr/bean/impl/BriefBeanImpl.java
@@ -26,6 +26,9 @@ public class BriefBeanImpl extends IdBeanImpl implements BriefBean {
     @Field("timestamp")
     protected Date timestamp;
 
+    @Field("foaf_organization")
+    private String[] organizations;
+
     @Field("PROVIDER")
     protected String[] provider;
 
@@ -166,6 +169,11 @@ public class BriefBeanImpl extends IdBeanImpl implements BriefBean {
         } else {
             return new String[0];
         }
+    }
+
+    @Override
+    public String[] getOrganizations() {
+        return (this.organizations != null ? this.organizations.clone() : null);
     }
 
     @Override


### PR DESCRIPTION
In case you need a test URL that has that field available, try
`../api/v2/search.json?query=paris&sort=europeana_id%20desc&profile=debug&wskey=...`

I still don't understand where this field is now added. According to Monica, it was added and indexed in http://reindex.eanadev.org:9393/solr but she added that it might also be available in Production because Simon "added it directly" there (Twilight Zone music). Because neither Monica, I, nor anyone else I asked has a clue what adding directly means in this context, here's the route to the Solr instance it was added to in the regular way, using indexing:

```
solr1.id            = solr-reindex-prod-publish3
solr1.url           = http://reindex.eanadev.org:9393/solr
solr1.zookeeper.url = reindex.eanadev.org:2383
solr1.core          = search_production_publish_3
```
