### PR TITLE
fixed bug that caused an Aggregation with no webresources to erase pr…

### DIFF
--- a/corelib-storage/src/main/java/eu/europeana/corelib/edm/utils/EdmUtils.java
+++ b/corelib-storage/src/main/java/eu/europeana/corelib/edm/utils/EdmUtils.java
@@ -554,8 +554,10 @@ public final class EdmUtils {
             }
             addAsList(aggregation, Rights.class, aggr.getDcRights());
             addAsList(aggregation, HasView.class, aggr.getHasView());
-            EdmWebResourceUtils.createWebResources(rdf, aggr, preserveIdentifiers);
             aggregationList.add(aggregation);
+            if (aggr.getWebResources() != null && !aggr.getWebResources().isEmpty()) {
+                EdmWebResourceUtils.createWebResources(rdf, aggr, preserveIdentifiers);
+            }
         }
         rdf.setAggregationList(aggregationList);
     }

--- a/corelib-storage/src/main/java/eu/europeana/corelib/edm/utils/EdmWebResourceUtils.java
+++ b/corelib-storage/src/main/java/eu/europeana/corelib/edm/utils/EdmWebResourceUtils.java
@@ -82,7 +82,9 @@ public class EdmWebResourceUtils {
             setIsReferencedBy(wr, wResource);
             webResources.add(wResource);
         }
-
+        if (rdf.getWebResourceList() != null && !rdf.getWebResourceList().isEmpty()) {
+            webResources.addAll(rdf.getWebResourceList());
+        }
         rdf.setWebResourceList(webResources);
     }
 


### PR DESCRIPTION
fixed bug that caused an Aggregation with no Webresources present to erase the Webresources added to the RDF object by a previous Aggregation, e.g.

FullBean@123456789
- Aggregation_1 [55 Webresources]
- Aggregation_2 [0 Webresources]

### +++ PROCESSING +++

=> RDF@123456789.setWebresourceList(55 Webresources)
*next Aggregation* *PING*
=> RDF@123456789.setWebresourceList(**NULL**)

### Result: 
=> RDF@123456789.getWebresourceList()
>$ Sorry, no webresources for @123456789. 

### FIXED by:

1. adding a not-null & not-empty check in EdmUtils.appendAggregation() (preventing erasing previously added Webresources, in case an Aggregation has no webresources at all)
2. adding a condition in EdmWebResourceUtils.createWebResources() to append the Webresources if the RDF object already has some, instead of just setting them (preventing replacing previously added Webresources, in case more than one Aggregation has Webresources)