### PR TITLE
corelib-Changes for consuming new nqf parameter

### DIFF
--- a/corelib-search/src/main/java/eu/europeana/corelib/search/SearchService.java
+++ b/corelib-search/src/main/java/eu/europeana/corelib/search/SearchService.java
@@ -28,10 +28,11 @@ public interface SearchService {
      * @param beanInterface  The required bean type, should be ApiBean or BriefBean
      * @param query          Model class containing the calculateTag specification.
      * @param debug			 includes the string representing the Solrquery in the ResultSet
+     * @param  divideQueryRefinements  control if  refinement array is processed and additional tag elements are appended  .
      * @return               The calculateTag results, including facets, breadcrumb and original query.
      * @throws EuropeanaException
      */
-    <T extends IdBean> ResultSet<T> search(SolrClient solrClient, Class<T> beanInterface, Query query, boolean debug) throws EuropeanaException;
+    <T extends IdBean> ResultSet<T> search(SolrClient solrClient, Class<T> beanInterface, Query query, boolean debug,boolean divideQueryRefinements) throws EuropeanaException;
     /**
      * Perform a calculateTag in SOLR based on the given query and return the results
      * in the format of the given class.
@@ -42,7 +43,7 @@ public interface SearchService {
      * @return               The calculateTag results, including facets, breadcrumb and original query.
      * @throws EuropeanaException
      */
-    <T extends IdBean> ResultSet<T> search(SolrClient solrClient, Class<T> beanInterface, Query query) throws EuropeanaException;
+    <T extends IdBean> ResultSet<T> search(SolrClient solrClient, Class<T> beanInterface, Query query,boolean divideQueryRefinements) throws EuropeanaException;
 
     /**
      * @param solrClient     The underlying Solr client to use for query

--- a/corelib-search/src/main/java/eu/europeana/corelib/search/impl/SearchServiceImpl.java
+++ b/corelib-search/src/main/java/eu/europeana/corelib/search/impl/SearchServiceImpl.java
@@ -70,8 +70,8 @@ public class SearchServiceImpl implements SearchService {
      */
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends IdBean> ResultSet<T> search(SolrClient solrClient, Class<T> beanInterface, Query query) throws EuropeanaException {
-        return search(solrClient, beanInterface, query, false);
+    public <T extends IdBean> ResultSet<T> search(SolrClient solrClient, Class<T> beanInterface, Query query,boolean divideRefinements) throws EuropeanaException {
+        return search(solrClient, beanInterface, query, false,divideRefinements);
     }
 
     /**
@@ -79,7 +79,7 @@ public class SearchServiceImpl implements SearchService {
      */
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends IdBean> ResultSet<T> search(SolrClient solrClient,  Class<T> beanInterface, Query query, boolean debug) throws EuropeanaException {
+    public <T extends IdBean> ResultSet<T> search(SolrClient solrClient,  Class<T> beanInterface, Query query, boolean debug,boolean divideRefinements ) throws EuropeanaException {
 
         if (query.getStart() != null && (query.getStart() + query.getPageSize() > searchLimit)) {
             throw new SolrQueryException(ProblemType.SEARCH_PAGE_LIMIT_REACHED,
@@ -90,7 +90,7 @@ public class SearchServiceImpl implements SearchService {
                 .getImplementationClass(beanInterface);
 
         if (isValidBeanClass(beanClazz)) {
-            String[] refinements = query.getRefinements(true);
+            String[] refinements = query.getRefinements(divideRefinements);
 
             SolrQuery solrQuery = new SolrQuery().setQuery(query.getQuery());
 

--- a/corelib-search/src/test/java/eu/europeana/corelib/search/RecordSearchServiceTest.java
+++ b/corelib-search/src/test/java/eu/europeana/corelib/search/RecordSearchServiceTest.java
@@ -145,7 +145,7 @@ public class RecordSearchServiceTest {
         testCount++;
         Query query = new Query("musi");
         query.setDefaultSolrFacets();
-        ResultSet<BriefBean> results = searchService.search(solrServer, BriefBean.class, query);
+        ResultSet<BriefBean> results = searchService.search(solrServer, BriefBean.class, query,true);
         Assert.assertNull(results.getSpellcheck());
     }
 
@@ -184,7 +184,7 @@ public class RecordSearchServiceTest {
         testCount++;
         Query query = new Query("*:*");
         query.setDefaultSolrFacets();
-        ResultSet<BriefBean> results = searchService.search(solrServer, BriefBean.class, query);
+        ResultSet<BriefBean> results = searchService.search(solrServer, BriefBean.class, query,true);
         assertFalse("No results given back... ", results.getResults().isEmpty());
 
         // TODO: wire up database providers
@@ -211,7 +211,7 @@ public class RecordSearchServiceTest {
         Query query = new Query("keyboard");
 
         query.setSort("score descending timestamp_created asc+timestamp_update,COMPLETENESS");
-        ResultSet<BriefBean> results = searchService.search(solrServer,BriefBean.class, query);
+        ResultSet<BriefBean> results = searchService.search(solrServer,BriefBean.class, query,true);
         assertNotNull(results);
         assertTrue(results.getResultSize() > 0);
     }


### PR DESCRIPTION
For controlling whether the refinement array elements needs to be divided and processed separately  based on search api input parameters ,new method parameter added in search method. Originally all refinements were being divided and and during processing the  tag is being appended to them  , which is not required as mentioned in ticket EA-3688